### PR TITLE
fix(codex): make 'esc' move into normal mode in codex

### DIFF
--- a/lua/add_plugins/codexnvim.lua
+++ b/lua/add_plugins/codexnvim.lua
@@ -247,11 +247,10 @@ return {
           end
         end
 
-        -- In terminal mode: leave terminal and close Codex
+        -- In terminal mode: leave terminal without immediately closing Codex
         vim.keymap.set("t", "<Esc>", function()
           api.nvim_feedkeys(esc_termcode, "nx", false)
-          vim.schedule(handle_escape)
-        end, { buffer = buf, noremap = true, silent = true, desc = "Codex: close on Esc (terminal)" })
+        end, { buffer = buf, noremap = true, silent = true, desc = "Codex: exit terminal on Esc" })
 
         -- In normal mode: close Codex directly
         vim.keymap.set(


### PR DESCRIPTION
instead of 'esc' immediately closing the codex buffer it first moves into normal mode to be able to navigate with nvim commands the answer, only if pressed in normal mode closes the buffer.